### PR TITLE
Asynchronization

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: WorldStyler
 main: muqsit\worldstyler\WorldStyler
-api: [3.0.0-ALPHA12, 3.0.0]
+api: 3.0.0
 version: 1.0
 
 commands:

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,0 +1,4 @@
+# Configuration for WorldStyler
+
+# Whether to execute everything asynchronously.
+use-async-tasks: false

--- a/src/muqsit/worldstyler/Selection.php
+++ b/src/muqsit/worldstyler/Selection.php
@@ -15,10 +15,23 @@ class Selection {
     private $clipboard;
 
     /** @var Vector3 */
-    private $clipboard_perspective;
+    private $clipboard_relative_pos;
 
     /** @var Vector3 */
     private $clipboard_caps;
+
+    /** @var int */
+    private $id;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId() : int
+    {
+        return $this->id;
+    }
 
     public function setClipboard(array $blockArray, Vector3 $relative_pos, Vector3 $caps) : void
     {

--- a/src/muqsit/worldstyler/WorldStyler.php
+++ b/src/muqsit/worldstyler/WorldStyler.php
@@ -3,16 +3,16 @@
 declare(strict_types=1);
 namespace muqsit\worldstyler;
 
-use muqsit\worldstyler\schematics\Schematic;
-use muqsit\worldstyler\shapes\CommonShape;
-use muqsit\worldstyler\shapes\Cuboid;
-use muqsit\worldstyler\utils\Utils;
+use muqsit\worldstyler\executors\CopyCommandExecutor;
+use muqsit\worldstyler\executors\PasteCommandExecutor;
+use muqsit\worldstyler\executors\PosCommandExecutor;
+use muqsit\worldstyler\executors\ReplaceCommandExecutor;
+use muqsit\worldstyler\executors\SchemCommandExecutor;
+use muqsit\worldstyler\executors\SetCommandExecutor;
+use muqsit\worldstyler\executors\StackCommandExecutor;
 
-use pocketmine\command\Command;
-use pocketmine\command\CommandSender;
 use pocketmine\Player;
 use pocketmine\plugin\PluginBase;
-use pocketmine\utils\TextFormat as TF;
 
 class WorldStyler extends PluginBase {
 
@@ -32,6 +32,16 @@ class WorldStyler extends PluginBase {
         }
 
         $this->saveResource("config.yml");
+
+        $commands = $this->getServer()->getCommandMap();
+        $commands->getCommand("/copy")->setExecutor(new CopyCommandExecutor($this));
+        $commands->getCommand("/paste")->setExecutor(new PasteCommandExecutor($this));
+        $commands->getCommand("/pos1")->setExecutor(new PosCommandExecutor($this, 1));
+        $commands->getCommand("/pos2")->setExecutor(new PosCommandExecutor($this, 2));
+        $commands->getCommand("/replace")->setExecutor(new ReplaceCommandExecutor($this));
+        $commands->getCommand("/schem")->setExecutor(new SchemCommandExecutor($this));
+        $commands->getCommand("/set")->setExecutor(new SetCommandExecutor($this));
+        $commands->getCommand("/stack")->setExecutor(new StackCommandExecutor($this));
     }
 
     public function getPlayerSelection(Player $player) : ?Selection
@@ -47,233 +57,5 @@ class WorldStyler extends PluginBase {
     public function removeSelection(int $pid) : void
     {
         unset($this->selections[$pid]);
-    }
-
-    public function onCommand(CommandSender $issuer, Command $cmd, $label, array $args) : bool
-    {
-        $cmd = $cmd->getName();
-        switch ($cmd) {
-            case '/pos1':
-                $this->getPlayerSelection($issuer)->setPosition(1, $issuer->asVector3());
-                $issuer->sendMessage(TF::GREEN . 'Selected position #1 as X=' . $issuer->x . ', Y=' . $issuer->y . ', Z=' . $issuer->z);
-                return true;
-            case '/pos2':
-                $this->getPlayerSelection($issuer)->setPosition(2, $issuer->asVector3());
-                $issuer->sendMessage(TF::GREEN . 'Selected position #2 as X=' . $issuer->x . ', Y=' . $issuer->y . ', Z=' . $issuer->z);
-                return true;
-            case '/copy':
-                $selection = $this->getPlayerSelection($issuer);
-                $count = $selection->getPositionCount();
-
-                if ($count < 2) {
-                    $issuer->sendMessage(TF::RED . 'You have not selected enough vertices.');
-                    return false;
-                }
-
-                $cuboid = Cuboid::fromSelection($selection);
-                if ($this->getConfig()->get("use-async-tasks", false)) {
-                    $cuboid = $cuboid->async();
-                }
-
-                $cuboid->copy(
-                    $issuer->getLevel(),
-                    $issuer->asVector3(),
-                    function (float $time, int $changed) use ($issuer) : void {
-                        $issuer->sendMessage(TF::GREEN . 'Copied ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's into your clipboard.');
-                    }
-                );
-                return true;
-            case '/paste':
-                $selection = $this->getPlayerSelection($issuer);
-
-                if (!$selection->hasClipboard()) {
-                    $issuer->sendMessage(TF::RED . 'You have copied nothing into your clipboard.');
-                    return false;
-                }
-
-                $air = !(isset($args[0]) && $args[0] === "noair");
-
-                $common_shape = CommonShape::fromSelection($selection);
-                if ($this->getConfig()->get("use-async-tasks", false)) {
-                    $cuboid = $common_shape->async();
-                }
-
-                $common_shape->paste(
-                    $issuer->getLevel(),
-                    $issuer->asVector3(),
-                    $air,
-                    function (float $time, int $changed) use ($issuer, $air) : void {
-                        $issuer->sendMessage(TF::GREEN . 'Pasted ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's from your clipboard' . ($air ? null : ' (no-air)') . '.');
-                    }
-                );
-                return true;
-            case '/stack':
-                $selection = $this->getPlayerSelection($issuer);
-
-                if (!$selection->hasClipboard()) {
-                    $issuer->sendMessage(TF::RED . 'You have copied nothing into your clipboard.');
-                    return false;
-                }
-
-                if (!isset($args[0]) || !is_numeric($args[0]) || strpos($args[0], '.') !== false || $args[0] <= 0) {
-                    $issuer->sendMessage(TF::RED . '//stack <repititions>');
-                    return false;
-                }
-
-                $air = !(isset($args[1]) && $args[1] === "noair");
-
-                $common_shape = CommonShape::fromSelection($selection);
-                if ($this->getConfig()->get("use-async-tasks", false)) {
-                    $cuboid = $common_shape->async();
-                }
-
-                $increase = $issuer->getDirectionVector()->round();
-                $repititions = (int) $args[0];
-
-                $issuer->sendMessage(TF::YELLOW . 'Stacking (Multiplying by ' . $increase->__toString() . ')...');
-
-                $common_shape->stack(
-                    $issuer->getLevel(),
-                    $issuer->asVector3(),
-                    $increase,
-                    $repititions,
-                    $air,
-                    function (float $time, int $changed) use ($issuer, $air) : void {
-                        $issuer->sendMessage(TF::GREEN . 'Stacked ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's from your clipboard' . ($air ? null : ' (no-air)') . '.');
-                    }
-                );
-                return true;
-            case '/set':
-                $selection = $this->getPlayerSelection($issuer);
-                $count = $selection->getPositionCount();
-
-                if ($count < 2) {
-                    $issuer->sendMessage(TF::RED . 'You have not selected enough vertices.');
-                    return false;
-                }
-
-                if (!isset($args[0])) {
-                    $issuer->sendMessage(TF::RED . '//set <block>');
-                    return false;
-                }
-
-                $block = Utils::getBlockFromString($args[0]);
-                if ($block === null) {
-                    $issuer->sendMessage(TF::RED . 'Invalid block given.');
-                    return false;
-                }
-
-                $cuboid = Cuboid::fromSelection($selection);
-                if ($this->getConfig()->get("use-async-tasks", false)) {
-                    $cuboid = $cuboid->async();
-                }
-
-                $cuboid->set(
-                    $issuer->getLevel(),
-                    $block,
-                    function (float $time, int $changed) use ($issuer) : void {
-                        $issuer->sendMessage(TF::GREEN . 'Set ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's');
-                    }
-                );
-                return true;
-            case '/replace':
-                $selection = $this->getPlayerSelection($issuer);
-                $count = $selection->getPositionCount();
-                if ($count < 2) {
-                    $issuer->sendMessage(TF::RED . 'You have not selected enough vertices.');
-                    return false;
-                }
-                if (!isset($args[1])) {
-                    $issuer->sendMessage(TF::RED . '//replace <blockToReplace> <replacementBlock>');
-                    return false;
-                }
-
-                [$block1, $block2] = $args;
-
-                $block1 = Utils::getBlockFromString($block1);
-                if ($block1 === null) {
-                    $issuer->sendMessage(TF::RED . 'Invalid block ' . $block1 . ' given.');
-                    return false;
-                }
-
-                $block2 = Utils::getBlockFromString($block2);
-                if ($block2 === null) {
-                    $issuer->sendMessage(TF::RED . 'Invalid block ' . $block2 . ' given.');
-                    return false;
-                }
-
-                $cuboid = Cuboid::fromSelection($selection);
-                if ($this->getConfig()->get("use-async-tasks", false)) {
-                    $cuboid = $cuboid->async();
-                }
-
-                $cuboid->replace(
-                    $issuer->getLevel(),
-                    $block1,
-                    $block2,
-                    function (float $time, int $changed) use ($issuer) : void {
-                        $issuer->sendMessage(TF::GREEN . 'Replaced ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's');
-                    }
-                );
-                return true;
-            case '/schem':
-                if (!isset($args[0]) || ($args[0] !== 'list' && $args[0] !== 'paste') || ($args[0] === 'paste' && !isset($args[1]))) {
-                    $issuer->sendMessage(TF::RED . '//schem list');
-                    $issuer->sendMessage(TF::RED . '//schem paste <schematicname>');
-                    return false;
-                }
-
-                if ($args[0] === 'list') {
-                    $dir = $this->getDataFolder() . 'schematics/';
-                    if (!is_dir($dir)) {
-                        $issuer->sendMessage(TF::RED . 'Directory ' . $dir . ' does not exist.');
-                        return false;
-                    }
-
-                    $files = 0;
-                    $issuer->sendMessage(TF::YELLOW . 'Schematics:');
-                    foreach (scandir($dir) as $file) {
-                        $expl = explode(".", $file, 2);
-                        if (count($expl) === 2 && $expl[1] === 'schematic') {
-                            $issuer->sendMessage(TF::GREEN . ++$files . '. ' . $expl[0] . TF::GRAY . ' (' . Utils::humanFilesize($dir . $file) . ')');
-                        }
-                    }
-                    $issuer->sendMessage(TF::ITALIC . TF::GRAY . 'Found ' . $files . ' schematics!');
-                    return true;
-                }
-
-                if ($args[0] === 'paste') {
-                    $file = $this->getDataFolder() . 'schematics/' . $args[1] . '.schematic';
-                    if (!is_file($file)) {
-                        $issuer->sendMessage(TF::RED . 'File "' . $file . '" not found.');
-                        return false;
-                    }
-
-                    $schematic = new Schematic($file);
-                    $is_async = $this->getConfig()->get("use-async-tasks", false);
-
-                    if ($is_async) {
-                        $schematic = $schematic->async();
-                    } else {
-                        $schematic->load();
-                    }
-
-                    $schematic->paste(
-                        $issuer->getLevel(),
-                        $issuer->asVector3(),
-                        true,
-                        function (float $time, int $changed) use ($issuer) : void {
-                            $issuer->sendMessage(TF::GREEN . 'Took ' . number_format($time, 10) . 's to paste ' . number_format($changed) . ' blocks.');
-                        }
-                    );
-
-                    if (!$is_async) {
-                        $schematic->invalidate();
-                    }
-                }
-                return true;
-        }
-        $issuer->sendMessage(TF::RED . 'Invalid syntax.');
-        return false;
     }
 }

--- a/src/muqsit/worldstyler/WorldStyler.php
+++ b/src/muqsit/worldstyler/WorldStyler.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace muqsit\worldstyler;
 
 use muqsit\worldstyler\schematics\Schematic;
+use muqsit\worldstyler\shapes\CommonShape;
 use muqsit\worldstyler\shapes\Cuboid;
-use muqsit\worldstyler\shapes\ShapeUtils;
 use muqsit\worldstyler\utils\Utils;
 
 use pocketmine\command\Command;
@@ -93,9 +93,13 @@ class WorldStyler extends PluginBase {
 
                 $air = !(isset($args[0]) && $args[0] === "noair");
 
-                ShapeUtils::paste(
+                $common_shape = CommonShape::fromSelection($selection);
+                if ($this->getConfig()->get("use-async-tasks", false)) {
+                    $cuboid = $common_shape->async();
+                }
+
+                $common_shape->paste(
                     $issuer->getLevel(),
-                    $selection,
                     $issuer->asVector3(),
                     $air,
                     function (float $time, int $changed) use ($issuer, $air) : void {
@@ -118,14 +122,18 @@ class WorldStyler extends PluginBase {
 
                 $air = !(isset($args[1]) && $args[1] === "noair");
 
+                $common_shape = CommonShape::fromSelection($selection);
+                if ($this->getConfig()->get("use-async-tasks", false)) {
+                    $cuboid = $common_shape->async();
+                }
+
                 $increase = $issuer->getDirectionVector()->round();
                 $repititions = (int) $args[0];
 
                 $issuer->sendMessage(TF::YELLOW . 'Stacking (Multiplying by ' . $increase->__toString() . ')...');
 
-                ShapeUtils::stack(
+                $common_shape->stack(
                     $issuer->getLevel(),
-                    $selection,
                     $issuer->asVector3(),
                     $increase,
                     $repititions,

--- a/src/muqsit/worldstyler/executors/BaseCommandExecutor.php
+++ b/src/muqsit/worldstyler/executors/BaseCommandExecutor.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use muqsit\worldstyler\WorldStyler;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandExecutor;
+use pocketmine\command\CommandSender;
+
+abstract class BaseCommandExecutor implements CommandExecutor {
+
+    const OPT_REQUIRED = 0;
+    const OPT_OPTIONAL = 1;
+    const OPT_NO_VALUE = 2;
+
+    /** @var WorldStyler */
+    protected $plugin;
+
+    /** @var int[] */
+    protected $options = [];
+
+    public function __construct(WorldStyler $plugin)
+    {
+        $this->plugin = $plugin;
+        $this->initExecutor();
+    }
+
+    protected function initExecutor() : void
+    {
+    }
+
+    public function addOption(string $option, int $type, bool $is_long) : void
+    {
+        $this->options[($is_long ? "--" : "-") . $option] = $type;
+    }
+
+    protected function parseOptions(array $args, &$indexes) : array
+    {
+        $options = [];
+        $indexes = [];
+
+        if (!empty($this->options)) {
+            foreach ($args as $index => $arg) {
+                if ($arg{0} === "-") {
+                    $offset = 0;
+                    $len = strlen($arg);
+                    while ($offset < $len) {
+                        if (isset($this->options[$opt = substr($arg, 0, $offset)])) {
+                            $indexes[$index] = $index;
+                            $value = true;
+                            $type = $this->options[$opt];
+                            if ($type !== self::OPT_NO_VALUE) {
+                                $value = $offset === $len ? true : ltrim(substr($arg, $offset), "=");
+                                if ($value === "") {
+                                    $value = true;
+                                }
+                                if ($value === true && $type === self::OPT_REQUIRED) {
+                                    throw new MissingOptionException("Value of flag '{$opt}' is mandatory");
+                                }
+                            }
+
+                            $options[ltrim($opt, "-")] = $value;
+                            break;
+                        }
+                        ++$offset;
+                    }
+                }
+            }
+        }
+
+        return $options;
+    }
+
+    protected function getBool(string $option) : bool
+    {
+        return $option === "true" || $option === "1";
+    }
+
+    final public function onCommand(CommandSender $sender, Command $command, string $label, array $args) : bool
+    {
+        $opts = $this->parseOptions($args, $indexes);
+        $args = array_values(array_diff_key($args, $indexes));
+        return $this->onCommandExecute($sender, $command, $label, $args, $opts);
+    }
+
+    abstract public function onCommandExecute(CommandSender $sender, Command $command, string $label, array $args, array $opts) : bool;
+}

--- a/src/muqsit/worldstyler/executors/CopyCommandExecutor.php
+++ b/src/muqsit/worldstyler/executors/CopyCommandExecutor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use muqsit\worldstyler\shapes\Cuboid;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+use pocketmine\utils\TextFormat as TF;
+
+class CopyCommandExecutor extends BaseCommandExecutor {
+
+    protected function initExecutor() : void
+    {
+        $this->addOption("async", self::OPT_OPTIONAL, true);
+    }
+
+    public function onCommandExecute(CommandSender $sender, Command $command, string $label, array $args, array $opts) : bool
+    {
+        $selection = $this->plugin->getPlayerSelection($sender);
+        $count = $selection->getPositionCount();
+
+        if ($count < 2) {
+            $sender->sendMessage(TF::RED . 'You have not selected enough vertices.');
+            return false;
+        }
+
+        $cuboid = Cuboid::fromSelection($selection);
+        $force_async = $opts["async"] ?? null;
+        if ($force_async !== null ? ($force_async = $this->getBool($force_async)) : $this->plugin->getConfig()->get("use-async-tasks", false)) {
+            $cuboid = $cuboid->async();
+        }
+
+        if ($force_async !== null) {
+            $sender->sendMessage(TF::GRAY . 'Asynchronous /' . $label . ' ' . ($force_async ? 'enabled' : 'disabled'));
+        }
+
+        $cuboid->copy(
+            $sender->getLevel(),
+            $sender->asVector3(),
+            function (float $time, int $changed) use ($sender) : void {
+                $sender->sendMessage(TF::GREEN . 'Copied ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's into your clipboard.');
+            }
+        );
+        return true;
+    }
+}

--- a/src/muqsit/worldstyler/executors/MissingOptionException.php
+++ b/src/muqsit/worldstyler/executors/MissingOptionException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use pocketmine\command\utils\CommandException;
+
+class MissingOptionException extends CommandException {
+}

--- a/src/muqsit/worldstyler/executors/PasteCommandExecutor.php
+++ b/src/muqsit/worldstyler/executors/PasteCommandExecutor.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use muqsit\worldstyler\shapes\CommonShape;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+use pocketmine\utils\TextFormat as TF;
+
+class PasteCommandExecutor extends BaseCommandExecutor {
+
+    protected function initExecutor() : void
+    {
+        $this->addOption("async", self::OPT_OPTIONAL, true);
+    }
+
+    public function onCommandExecute(CommandSender $sender, Command $command, string $label, array $args, array $opts) : bool
+    {
+        $selection = $this->plugin->getPlayerSelection($sender);
+
+        if (!$selection->hasClipboard()) {
+            $sender->sendMessage(TF::RED . 'You have copied nothing into your clipboard.');
+            return false;
+        }
+
+        $air = !(isset($args[0]) && $args[0] === "noair");
+
+        $common_shape = CommonShape::fromSelection($selection);
+        $force_async = $opts["async"] ?? null;
+        if ($force_async !== null ? ($force_async = $this->getBool($force_async)) : $this->plugin->getConfig()->get("use-async-tasks", false)) {
+            $cuboid = $common_shape->async();
+        }
+
+        if ($force_async !== null) {
+            $sender->sendMessage(TF::GRAY . 'Asynchronous /' . $label . ' ' . ($force_async ? 'enabled' : 'disabled'));
+        }
+
+        $common_shape->paste(
+            $sender->getLevel(),
+            $sender->asVector3(),
+            $air,
+            function (float $time, int $changed) use ($sender, $air) : void {
+                $sender->sendMessage(TF::GREEN . 'Pasted ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's from your clipboard' . ($air ? null : ' (no-air)') . '.');
+            }
+        );
+        return true;
+    }
+}

--- a/src/muqsit/worldstyler/executors/PosCommandExecutor.php
+++ b/src/muqsit/worldstyler/executors/PosCommandExecutor.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use muqsit\worldstyler\WorldStyler;
+use muqsit\worldstyler\shapes\Cuboid;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+use pocketmine\utils\TextFormat as TF;
+
+class PosCommandExecutor extends BaseCommandExecutor {
+
+    /** @var int */
+    private $position_index;
+
+    public function __construct(WorldStyler $plugin, int $position_index)
+    {
+        parent::__construct($plugin);
+        $this->position_index = $position_index;
+    }
+
+    public function onCommandExecute(CommandSender $sender, Command $command, string $label, array $args, array $opts) : bool
+    {
+        $this->plugin->getPlayerSelection($sender)->setPosition($this->position_index, $sender->asVector3());
+        $sender->sendMessage(TF::GREEN . 'Selected position #' . $this->position_index . ' as X=' . $sender->getFloorX() . ', Y=' . $sender->getFloorY() . ', Z=' . $sender->getFloorZ());
+        return true;
+    }
+}

--- a/src/muqsit/worldstyler/executors/ReplaceCommandExecutor.php
+++ b/src/muqsit/worldstyler/executors/ReplaceCommandExecutor.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use muqsit\worldstyler\shapes\Cuboid;
+use muqsit\worldstyler\utils\Utils;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+use pocketmine\utils\TextFormat as TF;
+
+class ReplaceCommandExecutor extends BaseCommandExecutor {
+
+    protected function initExecutor() : void
+    {
+        $this->addOption("async", self::OPT_OPTIONAL, true);
+    }
+
+    public function onCommandExecute(CommandSender $sender, Command $command, string $label, array $args, array $opts) : bool
+    {
+        $selection = $this->plugin->getPlayerSelection($sender);
+
+        $count = $selection->getPositionCount();
+        if ($count < 2) {
+            $sender->sendMessage(TF::RED . 'You have not selected enough vertices.');
+            return false;
+        }
+
+        if (!isset($args[1])) {
+            $sender->sendMessage(TF::RED . '//replace <blockToReplace> <replacementBlock>');
+            return false;
+        }
+
+        [$block1, $block2] = $args;
+
+        $block1 = Utils::getBlockFromString($block1);
+        if ($block1 === null) {
+            $sender->sendMessage(TF::RED . 'Invalid block ' . $block1 . ' given.');
+            return false;
+        }
+
+        $block2 = Utils::getBlockFromString($block2);
+        if ($block2 === null) {
+            $sender->sendMessage(TF::RED . 'Invalid block ' . $block2 . ' given.');
+            return false;
+        }
+
+        $cuboid = Cuboid::fromSelection($selection);
+        $force_async = $opts["async"] ?? null;
+        if ($force_async !== null ? ($force_async = $this->getBool($force_async)) : $this->plugin->getConfig()->get("use-async-tasks", false)) {
+            $cuboid = $cuboid->async();
+        }
+
+        if ($force_async !== null) {
+            $sender->sendMessage(TF::GRAY . 'Asynchronous /' . $label . ' ' . ($force_async ? 'enabled' : 'disabled'));
+        }
+
+        $cuboid->replace(
+            $sender->getLevel(),
+            $block1,
+            $block2,
+            function (float $time, int $changed) use ($sender) : void {
+                $sender->sendMessage(TF::GREEN . 'Replaced ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's');
+            }
+        );
+        return true;
+    }
+}

--- a/src/muqsit/worldstyler/executors/SchemCommandExecutor.php
+++ b/src/muqsit/worldstyler/executors/SchemCommandExecutor.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use muqsit\worldstyler\schematics\Schematic;
+use muqsit\worldstyler\utils\Utils;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+
+use pocketmine\utils\TextFormat as TF;
+
+class SchemCommandExecutor extends BaseCommandExecutor {
+
+    protected function initExecutor() : void
+    {
+        $this->addOption("async", self::OPT_OPTIONAL, true);
+    }
+
+    public function onCommandExecute(CommandSender $sender, Command $command, string $label, array $args, array $opts) : bool
+    {
+        if (!isset($args[0]) || ($args[0] !== 'list' && $args[0] !== 'paste') || ($args[0] === 'paste' && !isset($args[1]))) {
+            $sender->sendMessage(TF::RED . '//schem list');
+            $sender->sendMessage(TF::RED . '//schem paste <schematicname>');
+            return false;
+        }
+
+        if ($args[0] === 'list') {
+            $dir = $this->plugin->getDataFolder() . 'schematics/';
+            if (!is_dir($dir)) {
+                $sender->sendMessage(TF::RED . 'Directory ' . $dir . ' does not exist.');
+                return false;
+            }
+
+            $files = 0;
+            $sender->sendMessage(TF::YELLOW . 'Schematics:');
+            foreach (scandir($dir) as $file) {
+                $expl = explode(".", $file, 2);
+                if (count($expl) === 2 && $expl[1] === 'schematic') {
+                    $sender->sendMessage(TF::GREEN . ++$files . '. ' . $expl[0] . TF::GRAY . ' (' . Utils::humanFilesize($dir . $file) . ')');
+                }
+            }
+            $sender->sendMessage(TF::ITALIC . TF::GRAY . 'Found ' . $files . ' schematics!');
+            return true;
+        }
+
+        if ($args[0] === 'paste') {
+            $file = $this->plugin->getDataFolder() . 'schematics/' . $args[1] . '.schematic';
+            if (!is_file($file)) {
+                $sender->sendMessage(TF::RED . 'File "' . $file . '" not found.');
+                return false;
+            }
+
+            $schematic = new Schematic($file);
+            $force_async = $opts["async"] ?? null;
+            $is_async = $force_async !== null ? ($force_async = $this->getBool($force_async)) : $this->plugin->getConfig()->get("use-async-tasks", false);
+
+            if ($force_async !== null) {
+                $sender->sendMessage(TF::GRAY . 'Asynchronous /' . $label . ' ' . ($force_async ? 'enabled' : 'disabled'));
+            }
+
+            if ($is_async) {
+                $schematic = $schematic->async();
+            } else {
+                $schematic->load();
+            }
+
+            $schematic->paste(
+                $sender->getLevel(),
+                $sender->asVector3(),
+                true,
+                function (float $time, int $changed) use ($sender) : void {
+                    $sender->sendMessage(TF::GREEN . 'Took ' . number_format($time, 10) . 's to paste ' . number_format($changed) . ' blocks.');
+                }
+            );
+
+            if (!$is_async) {
+                $schematic->invalidate();
+            }
+        }
+        return true;
+    }
+}

--- a/src/muqsit/worldstyler/executors/SetCommandExecutor.php
+++ b/src/muqsit/worldstyler/executors/SetCommandExecutor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use muqsit\worldstyler\shapes\Cuboid;
+use muqsit\worldstyler\utils\Utils;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+
+use pocketmine\utils\TextFormat as TF;
+
+class SetCommandExecutor extends BaseCommandExecutor {
+
+    protected function initExecutor() : void
+    {
+        $this->addOption("async", self::OPT_OPTIONAL, true);
+    }
+
+    public function onCommandExecute(CommandSender $sender, Command $command, string $label, array $args, array $opts) : bool
+    {
+        $selection = $this->plugin->getPlayerSelection($sender);
+        $count = $selection->getPositionCount();
+
+        if ($count < 2) {
+            $sender->sendMessage(TF::RED . 'You have not selected enough vertices.');
+            return false;
+        }
+
+        if (!isset($args[0])) {
+            $sender->sendMessage(TF::RED . '//set <block>');
+            return false;
+        }
+
+        $block = Utils::getBlockFromString($args[0]);
+        if ($block === null) {
+            $sender->sendMessage(TF::RED . 'Invalid block given.');
+            return false;
+        }
+
+        $cuboid = Cuboid::fromSelection($selection);
+        $force_async = $opts["async"] ?? null;
+        if ($force_async !== null ? ($force_async = $this->getBool($force_async)) : $this->plugin->getConfig()->get("use-async-tasks", false)) {
+            $cuboid = $cuboid->async();
+        }
+
+        if ($force_async !== null) {
+            $sender->sendMessage(TF::GRAY . 'Asynchronous /' . $label . ' ' . ($force_async ? 'enabled' : 'disabled'));
+        }
+
+        $cuboid->set(
+            $sender->getLevel(),
+            $block,
+            function (float $time, int $changed) use ($sender) : void {
+                $sender->sendMessage(TF::GREEN . 'Set ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's');
+            }
+        );
+        return true;
+    }
+}

--- a/src/muqsit/worldstyler/executors/StackCommandExecutor.php
+++ b/src/muqsit/worldstyler/executors/StackCommandExecutor.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\executors;
+
+use muqsit\worldstyler\shapes\CommonShape;
+
+use pocketmine\command\Command;
+use pocketmine\command\CommandSender;
+
+use pocketmine\utils\TextFormat as TF;
+
+class StackCommandExecutor extends BaseCommandExecutor {
+
+    protected function initExecutor() : void
+    {
+        $this->addOption("async", self::OPT_OPTIONAL, true);
+    }
+
+    public function onCommandExecute(CommandSender $sender, Command $command, string $label, array $args, array $opts) : bool
+    {
+        $selection = $this->plugin->getPlayerSelection($sender);
+
+        if (!$selection->hasClipboard()) {
+            $sender->sendMessage(TF::RED . 'You have copied nothing into your clipboard.');
+            return false;
+        }
+
+        if (!isset($args[0]) || !is_numeric($args[0]) || strpos($args[0], '.') !== false || $args[0] <= 0) {
+            $sender->sendMessage(TF::RED . '//stack <repititions>');
+            return false;
+        }
+
+        $air = !(isset($args[1]) && $args[1] === "noair");
+
+        $common_shape = CommonShape::fromSelection($selection);
+        $force_async = $opts["async"] ?? null;
+        if ($force_async !== null ? ($force_async = $this->getBool($force_async)) : $this->plugin->getConfig()->get("use-async-tasks", false)) {
+            $cuboid = $common_shape->async();
+        }
+
+        if ($force_async !== null) {
+            $sender->sendMessage(TF::GRAY . 'Asynchronous /' . $label . ' ' . ($force_async ? 'enabled' : 'disabled'));
+        }
+
+        $increase = $sender->getDirectionVector()->round();
+        $repititions = (int) $args[0];
+
+        $sender->sendMessage(TF::YELLOW . 'Stacking (Multiplying by ' . $increase->__toString() . ')...');
+
+        $common_shape->stack(
+            $sender->getLevel(),
+            $sender->asVector3(),
+            $increase,
+            $repititions,
+            $air,
+            function (float $time, int $changed) use ($sender, $air) : void {
+                $sender->sendMessage(TF::GREEN . 'Stacked ' . number_format($changed) . ' blocks in ' . number_format($time, 10) . 's from your clipboard' . ($air ? null : ' (no-air)') . '.');
+            }
+        );
+        return true;
+    }
+}

--- a/src/muqsit/worldstyler/schematics/async/AsyncSchematic.php
+++ b/src/muqsit/worldstyler/schematics/async/AsyncSchematic.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\schematics\async;
+
+use muqsit\worldstyler\schematics\async\tasks\AsyncSchematicPasteTask;
+use muqsit\worldstyler\schematics\Schematic;
+
+use pocketmine\level\ChunkManager;
+use pocketmine\level\Level;
+use pocketmine\math\Vector3;
+
+class AsyncSchematic extends Schematic {
+
+    public function paste(ChunkManager $level, Vector3 $relative_pos, bool $replace_pc_blocks = true, ?callable $callable = null) : void
+    {
+        if (!($level instanceof Level)) {
+            throw new \InvalidArgumentException("\$level should be an instance of " . Level::class . " in asynchronous classes, got " . get_class($level));
+        }
+
+        $task = new AsyncSchematicPasteTask($relative_pos, $this->file, $replace_pc_blocks, $callable);
+        $task->setLevel($level);
+        $level->getServer()->getAsyncPool()->submitTask($task);
+    }
+}

--- a/src/muqsit/worldstyler/schematics/async/tasks/AsyncSchematicPasteTask.php
+++ b/src/muqsit/worldstyler/schematics/async/tasks/AsyncSchematicPasteTask.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\schematics\async\tasks;
+
+use muqsit\worldstyler\schematics\Schematic;
+use muqsit\worldstyler\shapes\async\tasks\AsyncChunksChangeTask;
+
+use pocketmine\level\Level;
+use pocketmine\math\Vector3;
+use pocketmine\Server;
+
+class AsyncSchematicPasteTask extends AsyncChunksChangeTask {
+
+    /** @var Vector3 */
+    private $relative_pos;
+
+    /** @var string */
+    private $file;
+
+    /** @var bool */
+    private $replace_pc_blocks;
+
+    public function __construct(Vector3 $relative_pos, string $file, bool $replace_pc_blocks = true, ?callable $callable)
+    {
+        $this->relative_pos = $relative_pos;
+        $this->file = $file;
+        $this->replace_pc_blocks = $replace_pc_blocks;
+        $this->setCallable($callable);
+    }
+
+    public function onRun() : void
+    {
+        $schematic = new Schematic($this->file);
+        $schematic->load();
+        $width = $schematic->getWidth();
+        $length = $schematic->getLength();
+        $this->publishProgress([$width, $length]);
+
+        while ($this->chunks === null);
+
+        $level = $this->getChunkManager();
+        $rel_pos = $this->relative_pos;
+        $schematic->paste($level, $rel_pos, $this->replace_pc_blocks, [$this, "updateStatistics"]);
+        $schematic->invalidate();
+
+        $this->saveChunks($level, $rel_pos, $rel_pos->add($width, 0, $length));
+    }
+
+    public function onProgressUpdate(Server $server, $progress) : void
+    {
+        $level = $server->getLevel($this->levelId);
+        [$width, $length] = $progress;
+
+        $chunks = [];
+
+        $rel_pos = $this->relative_pos;
+        $relx = $rel_pos->x;
+        $rely = $rel_pos->y;
+        $relz = $rel_pos->z;
+
+        for ($x = 0; $x < $width; ++$x) {
+            $chunkX = ($x + $relx) >> 4;
+            for ($z = 0; $z < $length; ++$z) {
+                $chunkZ = ($z + $relz) >> 4;
+                $chunks[Level::chunkHash($chunkX, $chunkZ)] = $level->getChunk($chunkX, $chunkZ, true);
+            }
+        }
+
+        $this->setChunks($chunks);
+    }
+}

--- a/src/muqsit/worldstyler/shapes/CommonShape.php
+++ b/src/muqsit/worldstyler/shapes/CommonShape.php
@@ -48,7 +48,7 @@ class CommonShape {
         };
 
         while (--$repetitions >= 0) {
-            CommonShape::paste($level, $start, $replace_air, $paste_callable);
+            $this->paste($level, $start, $replace_air, $paste_callable);
 
             $start->x += $xIncrease * $xCap;
             $start->y += $yIncrease * $yCap;

--- a/src/muqsit/worldstyler/shapes/CommonShape.php
+++ b/src/muqsit/worldstyler/shapes/CommonShape.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 namespace muqsit\worldstyler\shapes;
 
+use muqsit\worldstyler\shapes\async\AsyncCommonShape;
 use muqsit\worldstyler\Selection;
 use muqsit\worldstyler\utils\BlockIterator;
 use muqsit\worldstyler\utils\Utils;
@@ -12,14 +13,27 @@ use pocketmine\level\ChunkManager;
 use pocketmine\level\Level;
 use pocketmine\math\Vector3;
 
-class ShapeUtils {
+class CommonShape {
 
-    public static function stack(ChunkManager $level, Selection $selection, Vector3 $start, Vector3 $increase, int $repetitions, bool $replace_air = true, ?callable $callable = null) : void
+    public static function fromSelection(Selection $selection) : CommonShape
+    {
+        return new CommonShape($selection);
+    }
+
+    /** @var Selection */
+    public $selection;
+
+    public function __construct(Selection $selection)
+    {
+        $this->selection = $selection;
+    }
+
+    public function stack(ChunkManager $level, Vector3 $start, Vector3 $increase, int $repetitions, bool $replace_air = true, ?callable $callable = null) : void
     {
         $totalTime = 0;
         $changed = 0;
 
-        $caps = $selection->getClipboardCaps();
+        $caps = $this->selection->getClipboardCaps();
         $xCap = $caps->x;
         $yCap = $caps->y;
         $zCap = $caps->z;
@@ -34,7 +48,7 @@ class ShapeUtils {
         };
 
         while (--$repetitions >= 0) {
-            ShapeUtils::paste($level, $selection, $start, $replace_air, $paste_callable);
+            CommonShape::paste($level, $start, $replace_air, $paste_callable);
 
             $start->x += $xIncrease * $xCap;
             $start->y += $yIncrease * $yCap;
@@ -46,19 +60,19 @@ class ShapeUtils {
         }
     }
 
-    public static function paste(ChunkManager $level, Selection $selection, Vector3 $relative_pos, bool $replace_air = true, ?callable $callable) : void
+    public function paste(ChunkManager $level, Vector3 $relative_pos, bool $replace_air = true, ?callable $callable) : void
     {
         $changed = 0;
         $time = microtime(true);
 
-        $relative_pos = $relative_pos->floor()->add($selection->getClipboardRelativePos());
+        $relative_pos = $relative_pos->floor()->add($this->selection->getClipboardRelativePos());
         $relx = $relative_pos->x;
         $rely = $relative_pos->y;
         $relz = $relative_pos->z;
 
-        $clipboard = $selection->getClipboard();
+        $clipboard = $this->selection->getClipboard();
 
-        $caps = $selection->getClipboardCaps();
+        $caps = $this->selection->getClipboardCaps();
         $xCap = $caps->x;
         $yCap = $caps->y;
         $zCap = $caps->z;
@@ -91,5 +105,10 @@ class ShapeUtils {
         if ($callable !== null) {
             $callable($time, $changed);
         }
+    }
+
+    public function async() : AsyncCommonShape
+    {
+        return new AsyncCommonShape($this->selection);
     }
 }

--- a/src/muqsit/worldstyler/shapes/async/AsyncCommonShape.php
+++ b/src/muqsit/worldstyler/shapes/async/AsyncCommonShape.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async;
+
+use muqsit\worldstyler\shapes\async\tasks\AsyncCommonShapeStackTask;
+use muqsit\worldstyler\shapes\async\tasks\AsyncCommonShapePasteTask;
+use muqsit\worldstyler\shapes\CommonShape;
+
+use pocketmine\level\ChunkManager;
+use pocketmine\level\Level;
+use pocketmine\math\Vector3;
+
+class AsyncCommonShape extends CommonShape {
+
+    public function stack(ChunkManager $level, Vector3 $start, Vector3 $increase, int $repetitions, bool $replace_air = true, ?callable $callable = null) : void
+    {
+        if (!($level instanceof Level)) {
+            throw new \InvalidArgumentException("\$level should be an instance of " . Level::class . " in asynchronous classes, got " . get_class($level));
+        }
+
+        $chunks = [];
+
+        $caps = $this->selection->getClipboardCaps();
+        $minChunkX = ($start->x + ($increase->x * $caps->x)) >> 4;
+        $minChunkZ = ($start->z + ($increase->z * $caps->z)) >> 4;
+        $maxChunkX = ($start->x + ($increase->x * $caps->x * $repetitions)) >> 4;
+        $maxChunkZ = ($start->z + ($increase->z * $caps->z * $repetitions)) >> 4;
+
+        for ($chunkX = $minChunkX; $chunkX <= $maxChunkX; ++$chunkX) {
+            for ($chunkZ = $minChunkZ; $chunkZ <= $maxChunkZ; ++$chunkZ) {
+                $chunks[] = $level->getChunk($chunkX, $chunkZ, true);
+            }
+        }
+
+        $task = new AsyncCommonShapeStackTask(CommonShape::fromSelection($this->selection), $level, $chunks, $callable);
+        $task->startFrom($start);
+        $task->increaseBy($increase);
+        $task->repeat($repetitions);
+        $task->replaceAir($replace_air);
+        $level->getServer()->getAsyncPool()->submitTask($task);
+    }
+
+    public function paste(ChunkManager $level, Vector3 $relative_pos, bool $replace_air = true, ?callable $callable) : void
+    {
+        if (!($level instanceof Level)) {
+            throw new \InvalidArgumentException("\$level should be an instance of " . Level::class . " in asynchronous classes, got " . get_class($level));
+        }
+
+        $chunks = [];
+
+        $caps = $this->selection->getClipboardCaps();
+        $minChunkX = ($start->x + $caps->x) >> 4;
+        $minChunkZ = ($start->z + $caps->z) >> 4;
+        $maxChunkX = ($start->x + ($caps->x * $repetitions)) >> 4;
+        $maxChunkZ = ($start->z + ($caps->z * $repetitions)) >> 4;
+
+        for ($chunkX = $minChunkX; $chunkX <= $maxChunkX; ++$chunkX) {
+            for ($chunkZ = $minChunkZ; $chunkZ <= $maxChunkZ; ++$chunkZ) {
+                $chunks[] = $level->getChunk($chunkX, $chunkZ, true);
+            }
+        }
+
+        $task = new AsyncCommonShapePasteTask(CommonShape::fromSelection($this->selection), $level, $chunks, $callable);
+        $task->setRelativePos($relative_pos);
+        $task->replaceAir($replace_air);
+        $level->getServer()->getAsyncPool()->submitTask($task);
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/AsyncCuboid.php
+++ b/src/muqsit/worldstyler/shapes/async/AsyncCuboid.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async;
+
+use muqsit\worldstyler\shapes\async\tasks\AsyncCuboidCopyTask;
+use muqsit\worldstyler\shapes\async\tasks\AsyncCuboidReplaceTask;
+use muqsit\worldstyler\shapes\async\tasks\AsyncCuboidSetTask;
+use muqsit\worldstyler\shapes\Cuboid;
+
+use pocketmine\block\Block;
+use pocketmine\level\ChunkManager;
+use pocketmine\level\Level;
+use pocketmine\math\Vector3;
+
+class AsyncCuboid extends Cuboid {
+
+    public function copy(ChunkManager $level, Vector3 $relative_pos, ?callable $callable = null) : void
+    {
+        if (!($level instanceof Level)) {
+            throw new \InvalidArgumentException("\$level should be an instance of " . Level::class . " in asynchronous classes, got " . get_class($level));
+        }
+
+        $task = new AsyncCuboidCopyTask(Cuboid::fromSelection($this->selection), $level, $this->getChunks($level), $callable);
+        $task->setRelativePos($relative_pos);
+        $level->getServer()->getAsyncPool()->submitTask($task);
+    }
+
+    public function set(ChunkManager $level, Block $block, ?callable $callable = null) : void
+    {
+        if (!($level instanceof Level)) {
+            throw new \InvalidArgumentException("\$level should be an instance of " . Level::class . " in asynchronous classes, got " . get_class($level));
+        }
+
+        $task = new AsyncCuboidSetTask(Cuboid::fromSelection($this->selection), $level, $this->getChunks($level), $callable);
+        $task->setBlock($block);
+        $level->getServer()->getAsyncPool()->submitTask($task);
+    }
+
+    public function replace(ChunkManager $level, Block $find, Block $replace, ?callable $callable = null) : void
+    {
+        if (!($level instanceof Level)) {
+            throw new \InvalidArgumentException("\$level should be an instance of " . Level::class . " in asynchronous classes, got " . get_class($level));
+        }
+
+        $task = new AsyncCuboidReplaceTask(Cuboid::fromSelection($this->selection), $level, $this->getChunks($level), $callable);
+        $task->find($find);
+        $task->replace($replace);
+        $level->getServer()->getAsyncPool()->submitTask($task);
+    }
+
+    private function getChunks(Level $level, bool $create = true) : array
+    {
+        $chunks = [];
+
+        $minChunkX = $this->pos1->x >> 4;
+        $maxChunkX = $this->pos2->x >> 4;
+        $minChunkZ = $this->pos1->z >> 4;
+        $maxChunkZ = $this->pos2->z >> 4;
+
+        for ($chunkX = $minChunkX; $chunkX <= $maxChunkX; ++$chunkX) {
+            for ($chunkZ = $minChunkZ; $chunkZ <= $maxChunkZ; ++$chunkZ) {
+                $chunks[] = $level->getChunk($chunkX, $chunkZ, $create);
+            }
+        }
+
+        return $chunks;
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/tasks/AsyncChunksChangeTask.php
+++ b/src/muqsit/worldstyler/shapes/async/tasks/AsyncChunksChangeTask.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async\tasks;
+
+use pocketmine\level\format\Chunk;
+use pocketmine\level\Level;
+use pocketmine\level\SimpleChunkManager;
+use pocketmine\math\Vector3;
+use pocketmine\scheduler\AsyncTask;
+use pocketmine\Server;
+
+abstract class AsyncChunksChangeTask extends AsyncTask {
+
+    protected static function serialize($unserialized) : string
+    {
+        return extension_loaded("igbinary") ? igbinary_serialize($unserialized) : serialize($unserialized);
+    }
+
+    protected static function unserialize(string $serialized)
+    {
+        return extension_loaded("igbinary") ? igbinary_unserialize($serialized) : unserialize($serialized);
+    }
+
+    /** @var int */
+    protected $levelId;
+
+    /** @var int */
+    protected $seed;
+
+    /** @var int */
+    protected $worldHeight;
+
+    /** @var string */
+    protected $chunks;
+
+    /** @var int */
+    protected $changed;
+
+    /** @var float */
+    protected $time;
+
+    /** @var bool */
+    protected $set_chunks = true;
+
+    /** @var bool */
+    private $has_callable = false;
+
+    public function setLevel(Level $level) : void
+    {
+        $this->levelId = $level->getId();
+        $this->seed = $level->getSeed();
+        $this->worldHeight = $level->getWorldHeight();
+    }
+
+    public function updateStatistics(float $time, int $changed) : void
+    {
+        $this->time = $time;
+        $this->changed = $changed;
+    }
+
+    public function setChunks(array $chunks) : void
+    {
+        $serialized_chunks = [];
+        foreach ($chunks as $chunk) {
+            $serialized_chunks[Level::chunkHash($chunk->getX(), $chunk->getZ())] = $chunk->fastSerialize();
+        }
+
+        $this->chunks = self::serialize($serialized_chunks);
+    }
+
+    protected function setCallable(?callable $callable) : void
+    {
+        if ($callable !== null) {
+            $this->storeLocal($callable);
+            $this->has_callable = true;
+        }
+    }
+
+    protected function getChunkManager() : SimpleChunkManager
+    {
+        $manager = new SimpleChunkManager($this->seed, $this->worldHeight);
+
+        foreach (self::unserialize($this->chunks) as $hash => $serialized_chunk) {
+            Level::getXZ($hash, $chunkX, $chunkZ);
+            $manager->setChunk($chunkX, $chunkZ, Chunk::fastDeserialize($serialized_chunk));
+        }
+
+        return $manager;
+    }
+
+    public function saveChunks(SimpleChunkManager $level, Vector3 $pos1, Vector3 $pos2) : void
+    {
+        if (!$this->set_chunks) {
+            $this->chunks = null;
+            return;
+        }
+
+        $minChunkX = min($pos1->x, $pos2->x) >> 4;
+        $maxChunkX = max($pos1->x, $pos2->x) >> 4;
+        $minChunkZ = min($pos1->z, $pos2->z) >> 4;
+        $maxChunkZ = max($pos1->z, $pos2->z) >> 4;
+
+        $chunks = [];
+
+        for ($chunkX = $minChunkX; $chunkX <= $maxChunkX; ++$chunkX) {
+            for ($chunkZ = $minChunkZ; $chunkZ <= $maxChunkZ; ++$chunkZ) {
+                $chunks[Level::chunkHash($chunkX, $chunkZ)] = $level->getChunk($chunkX, $chunkZ)->fastSerialize();
+            }
+        }
+
+        $this->chunks = self::serialize($chunks);
+    }
+
+    public function onCompletion(Server $server) : void
+    {
+        if ($this->set_chunks) {
+            $level = $server->getLevel($this->levelId);
+            foreach (self::unserialize($this->chunks) as $hash => $chunk) {
+                Level::getXZ($hash, $chunkX, $chunkZ);
+                $level->setChunk($chunkX, $chunkZ, Chunk::fastDeserialize($chunk));
+            }
+        }
+
+        if ($this->has_callable) {
+            $this->fetchLocal()($this->time, $this->changed);
+        }
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/tasks/AsyncCommonShapePasteTask.php
+++ b/src/muqsit/worldstyler/shapes/async/tasks/AsyncCommonShapePasteTask.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async\tasks;
+
+use muqsit\worldstyler\shapes\CommonShape;
+
+use pocketmine\math\Vector3;
+
+class AsyncCommonShapePasteTask extends AsyncCommonShapeTask {
+
+    /** @var Vector3 */
+    private $relative_pos;
+
+    /** @var bool */
+    private $replace_air;
+
+    public function setRelativePos(Vector3 $relative_pos) : void
+    {
+        $this->relative_pos = $relative_pos;
+    }
+
+    public function replaceAir(bool $replace_air) : void
+    {
+        $this->replace_air = $replace_air;
+    }
+
+    public function onRun() : void
+    {
+        $level = $this->getChunkManager();
+        $common_shape = $this->getCommonShape();
+        $common_shape->paste($level, $this->relative_pos, $this->replace_air, [$this, "updateStatistics"]);
+
+        $caps = $common_shape->selection->getClipboardCaps();
+        $min_pos = $this->start->add($caps);
+        $max_pos = $min_pos->multiply($repetitions);
+        $this->saveChunks($level, $min_pos, $max_pos);
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/tasks/AsyncCommonShapeStackTask.php
+++ b/src/muqsit/worldstyler/shapes/async/tasks/AsyncCommonShapeStackTask.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async\tasks;
+
+use muqsit\worldstyler\shapes\CommonShape;
+
+use pocketmine\math\Vector3;
+
+class AsyncCommonShapeStackTask extends AsyncCommonShapeTask {
+
+    /** @var Vector3 */
+    private $start;
+
+    /** @var Vector3 */
+    private $increase;
+
+    /** @var int */
+    private $repetitions;
+
+    /** @var bool */
+    private $replace_air;
+
+    public function startFrom(Vector3 $pos) : void
+    {
+        $this->start = $pos;
+    }
+
+    public function increaseBy(Vector3 $pos) : void
+    {
+        $this->increase = $pos;
+    }
+
+    public function repeat(int $repetitions) : void
+    {
+        $this->repetitions = $repetitions;
+    }
+
+    public function replaceAir(bool $replace_air) : void
+    {
+        $this->replace_air = $replace_air;
+    }
+
+    public function onRun() : void
+    {
+        $level = $this->getChunkManager();
+        $common_shape = $this->getCommonShape();
+        $common_shape->stack($level, $this->start, $this->increase, $this->repetitions, $this->replace_air, [$this, "updateStatistics"]);
+
+        $caps = $common_shape->selection->getClipboardCaps();
+        $min_pos = $this->start->add($this->increase->x * $caps->x, 0, $this->increase->z * $caps->z);
+        $max_pos = $min_pos->multiply($repetitions);
+        $this->saveChunks($level, $min_pos, $max_pos);
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/tasks/AsyncCommonShapeTask.php
+++ b/src/muqsit/worldstyler/shapes/async/tasks/AsyncCommonShapeTask.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async\tasks;
+
+use muqsit\worldstyler\shapes\CommonShape;
+
+use pocketmine\level\Level;
+
+abstract class AsyncCommonShapeTask extends AsyncChunksChangeTask {
+
+    /** @var string */
+    private $common_shape;
+
+    public function __construct(CommonShape $common_shape, Level $level, array $chunks, ?callable $callable = null)
+    {
+        $this->common_shape = serialize($common_shape);
+
+        $this->setLevel($level);
+        $this->setChunks($chunks);
+        $this->setCallable($callable);
+    }
+
+    protected function getCommonShape() : CommonShape
+    {
+        return unserialize($this->common_shape);
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/tasks/AsyncCuboidCopyTask.php
+++ b/src/muqsit/worldstyler/shapes/async/tasks/AsyncCuboidCopyTask.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async\tasks;
+
+use muqsit\worldstyler\shapes\Cuboid;
+
+use pocketmine\block\Block;
+use pocketmine\math\Vector3;
+use pocketmine\Server;
+
+class AsyncCuboidCopyTask extends AsyncCuboidTask {
+
+    protected $set_chunks = false;
+
+    /** @var string */
+    private $clipboard;
+
+    /** @var string */
+    private $clipboard_caps;
+
+    /** @var Vector3 */
+    private $relative_pos;
+
+    /** @var Vector3 */
+    private $selectionId;
+
+    public function setRelativePos(Vector3 $relative_pos) : void
+    {
+        $this->relative_pos = $relative_pos;
+    }
+
+    public function onRun() : void
+    {
+        $level = $this->getChunkManager();
+        $cuboid = $this->getCuboid();
+
+        $cuboid->copy($level, $this->relative_pos, [$this, "updateStatistics"]);
+        $this->saveChunks($level, $cuboid->pos1, $cuboid->pos2);
+
+        $this->clipboard = self::serialize($cuboid->selection->getClipboard());
+        $this->relative_pos = $cuboid->selection->getClipboardRelativePos();
+        $this->clipboard_caps = self::serialize($cuboid->selection->getClipboardCaps());
+        $this->selectionId = $cuboid->selection->getId();
+    }
+
+    public function onCompletion(Server $server) : void
+    {
+        parent::onCompletion($server);
+
+        $selection = $server->getPluginManager()->getPlugin("WorldStyler")->getSelection($this->selectionId);
+        if ($selection !== null) {
+            $selection->setClipboard(self::unserialize($this->clipboard), $this->relative_pos, self::unserialize($this->clipboard_caps));
+        }
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/tasks/AsyncCuboidReplaceTask.php
+++ b/src/muqsit/worldstyler/shapes/async/tasks/AsyncCuboidReplaceTask.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async\tasks;
+
+use muqsit\worldstyler\shapes\Cuboid;
+
+use pocketmine\block\Block;
+
+class AsyncCuboidReplaceTask extends AsyncCuboidTask {
+
+    /** @var Block */
+    private $find;
+
+    /** @var Block */
+    private $replace;
+
+    public function find(Block $block) : void
+    {
+        $this->find = $block;
+    }
+
+    public function replace(Block $block) : void
+    {
+        $this->replace = $block;
+    }
+
+    public function onRun() : void
+    {
+        $level = $this->getChunkManager();
+        $cuboid = $this->getCuboid();
+
+        $cuboid->replace($level, $this->find, $this->replace, [$this, "updateStatistics"]);
+        $this->saveChunks($level, $cuboid->pos1, $cuboid->pos2);
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/tasks/AsyncCuboidSetTask.php
+++ b/src/muqsit/worldstyler/shapes/async/tasks/AsyncCuboidSetTask.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async\tasks;
+
+use muqsit\worldstyler\shapes\Cuboid;
+
+use pocketmine\block\Block;
+
+class AsyncCuboidSetTask extends AsyncCuboidTask {
+
+    /** @var Block */
+    private $block;
+
+    public function setBlock(Block $block) : void
+    {
+        $this->block = $block;
+    }
+
+    public function onRun() : void
+    {
+        $level = $this->getChunkManager();
+        $cuboid = $this->getCuboid();
+
+        $cuboid->set($level, $this->block, [$this, "updateStatistics"]);
+        $this->saveChunks($level, $cuboid->pos1, $cuboid->pos2);
+    }
+}

--- a/src/muqsit/worldstyler/shapes/async/tasks/AsyncCuboidTask.php
+++ b/src/muqsit/worldstyler/shapes/async/tasks/AsyncCuboidTask.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+namespace muqsit\worldstyler\shapes\async\tasks;
+
+use muqsit\worldstyler\shapes\Cuboid;
+
+use pocketmine\level\Level;
+
+abstract class AsyncCuboidTask extends AsyncChunksChangeTask {
+
+    /** @var string */
+    private $cuboid;
+
+    public function __construct(Cuboid $cuboid, Level $level, array $chunks, ?callable $callable = null)
+    {
+        $this->cuboid = serialize($cuboid);
+
+        $this->setLevel($level);
+        $this->setChunks($chunks);
+        $this->setCallable($callable);
+    }
+
+    protected function getCuboid() : Cuboid
+    {
+        return unserialize($this->cuboid);
+    }
+}

--- a/src/muqsit/worldstyler/utils/Utils.php
+++ b/src/muqsit/worldstyler/utils/Utils.php
@@ -6,7 +6,6 @@ namespace muqsit\worldstyler\utils;
 use pocketmine\block\Block;
 use pocketmine\block\BlockFactory;
 use pocketmine\block\WoodenFence;
-use pocketmine\block\UnknownBlock;
 use pocketmine\level\Level;
 
 class Utils {


### PR DESCRIPTION
## What is Asynchronization?
Asynchronization lets WorldStyler execute all it's tasks in the background so your server can still respond to players and handle incoming/outgoing packets rather than freezing the server until WorldStyler has finished execution.
That said, due to the way pthreads is designed, there *may* still be freezes at the start and end of the asynchronous job due to serialization and unserialization of chunks. It's not worth asynchronization for small jobs such as setting 1 million blocks (which would take around 2.5 seconds on an average hardware). [**Read this**](https://blog.falkirks.com/setting-huge-areas-of-blocks) for more information on asynchronization.

## Why do this?
Yeah, no one really uses a world editor to edit massive areas on a server with live players. But for those who live on the edge, you're welcome! Asynchronization won't freeze your server until WorldStyler is done editing your area.

## What if I don't want to world-edit asynchronously?
You're good! By default, `use-async-tasks` in the `config.yml` is set to `false`. You can keep it this way if you like to. If you still want to world-edit asynchronously, you can either set the value to `true` OR you can specify the `--async` flag in your commands. For example:
* `//replace stone air --async=true`//asynchronous
* `//replace --async=true stone air`//asynchronous, exactly same as above
* `//set stone --async=1`//asynchronous
* `//set stone --async=false`//synchronous
* `//stack --async=0`//synchronous
* `//paste --async`//asynchronous

The `--async` flag can be specified at any position of the command.
* If you only specify `--async`, the command is executed asynchronously.
* If you specify `--async=1` or `--async=true`, the command is executed asynchronously.
* If you specify `--async=0` or `--async=false` the command is executed synchronously.
* If you specify an invalid value like `--async=steve` the command is executed synchronously.

**NOTE:** The `--async` flag skips config-checking, so any value given to `use-async-tasks` in the `config.yml` will be ignored.

## Drawbacks
**Memory:** PocketMine's default `memory.async-worker-hard-limit` value is set to 256MB. That should be more than enough but the biggest a schematic can get is (**width:** 32767, **length:** 32767, **height:** 256). Let's just say any world editor plugin is capable of causing an out-of-memory error if handled carelessly.
**Serialization:** pthreads will attempt to serialize any object passed to it, which impacts performance in a way. WorldStyler supports igbinary serialization, you can cut down on this performance impact by installing the igbinary PHP extension (but note that the performance impact will still be there, just not as much). If you're editing only a small portion, asynchronization is only going to decrease the overall performance. It's only suitable for considerably large areas, yet the server *may* freeze at the beginning and the end of the asynchronous task.
**Hogging PocketMine's AsyncWorkers:** [Plugins/blocking operations hogging the AsyncWorkers causes significant server slowdown](https://github.com/pmmp/PocketMine-MP/issues/1161)